### PR TITLE
Manage profile directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ class {'proxy_client':
 }
 ```
 
+This module can ensure that folder /etc/profile.d exist on the system, default is false :
+
+```puppet
+class {'proxy_client':
+  manage_profile => true,
+  http_proxy     => 'http://proxy.example:3128',
+  https_proxy    => 'http://proxy.example:3128',
+  no_proxy       => ['puppet.example','10.0.99.1']
+}
+```
+
 ## Limitations
 
 Currently only supports RedHat.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,3 +1,7 @@
+# [*manage_profile*]
+# Boolean if true this modile ensure that $profile_d is a directory
+# default set to false
+#
 # Examples
 # --------
 #
@@ -9,14 +13,17 @@
 #    }
 #
 class proxy_client (
-  $http_proxy  = undef,
-  $https_proxy = undef,
-  $no_proxy    = [],
-  $profile_d   = $::proxy_client::params::profile_d,
+  $http_proxy     = undef,
+  $https_proxy    = undef,
+  $no_proxy       = [],
+  Boolean $manage_profile = false,
+  $profile_d      = $::proxy_client::params::profile_d,
 ) inherits proxy_client::params {
 
-  file {$profile_d:
-    ensure => directory,
+  if $manage_profile {
+    file { $profile_d:
+      ensure => directory,
+    }
   }
 
   file {'proxy_profile':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,11 +13,11 @@
 #    }
 #
 class proxy_client (
-  $http_proxy     = undef,
-  $https_proxy    = undef,
-  $no_proxy       = [],
+  $http_proxy             = undef,
+  $https_proxy            = undef,
+  $no_proxy               = [],
   Boolean $manage_profile = false,
-  $profile_d      = $::proxy_client::params::profile_d,
+  $profile_d              = $::proxy_client::params::profile_d,
 ) inherits proxy_client::params {
 
   if $manage_profile {


### PR DESCRIPTION
This PR add a variable in order to enable or disable the creation of /etc/profile.d directory.